### PR TITLE
chore(deps): go-1.20 is deprecated

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -91,7 +91,7 @@ jobs:
           - yarn-classic
           - yarn-berry
           - pnpm
-          - go-1.20
+          - go-1.21
           - go-latest
           - python-3.10-pip
           - python-3.12-pip

--- a/scenarios/go/simple/go.mod
+++ b/scenarios/go/simple/go.mod
@@ -1,6 +1,6 @@
 module example.com/simple
 
-go 1.20
+go 1.21
 
 require (
 	github.com/sirupsen/logrus v1.9.0

--- a/shared-scripts/setup-runtime.sh
+++ b/shared-scripts/setup-runtime.sh
@@ -58,15 +58,15 @@ case "$RUNTIME" in
     echo "Installed pnpm version:"
     pnpm -v
     ;;
-  "go-1.20")
-    echo "Installing Go 1.20..."
+  "go-1.21")
+    echo "Installing Go 1.21..."
     case "$OS" in
       macos)
         # Use Homebrew for Go on macOS
-        brew install go@1.20
-        # Set up Go 1.20 as default (keg-only formula)
-        export PATH="/opt/homebrew/opt/go@1.20/bin:$PATH"
-        export GOROOT="/opt/homebrew/opt/go@1.20/libexec"
+        brew install go@1.21
+        # Set up Go 1.21 as default (keg-only formula)
+        export PATH="/opt/homebrew/opt/go@1.21/bin:$PATH"
+        export GOROOT="/opt/homebrew/opt/go@1.21/libexec"
         # Persist environment variables for subsequent steps
         echo "PATH=$PATH" >> $GITHUB_ENV
         echo "GOROOT=$GOROOT" >> $GITHUB_ENV


### PR DESCRIPTION
Upgrade to go 1.21 because 1.20 was deprecated upstream:
```
[call-shared / integration-tests (macos-latest, go-1.20)](https://github.com/trustification/exhort-javascript-api/actions/runs/16368384035/job/46251365703#step:12:16)
go@1.20 has been deprecated because it is not supported upstream! It was disabled on 2025-02-19.
```